### PR TITLE
Redesign with sidebar navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { ThemeProvider } from "./theme-provider";
 import { ReactQueryProvider } from "./react-query-provider";
-import { Header } from "@/components/Header";
+import { Sidebar } from "@/components/Sidebar";
 
 const roboto = Roboto({
   subsets: ["latin"],
@@ -39,11 +39,14 @@ export default function RootLayout({
             disableTransitionOnChange
           >
             <ReactQueryProvider>
-              <Header />
-
-              {children}
-              <Analytics />
-              <SpeedInsights />
+              <div className="flex min-h-screen">
+                <Sidebar />
+                <main className="flex-1 md:ml-64 p-4">
+                  {children}
+                  <Analytics />
+                  <SpeedInsights />
+                </main>
+              </div>
             </ReactQueryProvider>
           </ThemeProvider>
         </body>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Menu, X, Calendar } from "lucide-react";
+import { Logo } from "./Logo";
+import { ModeToggle } from "./mode-toggle";
+import { cn } from "@/lib/utils";
+
+export function Sidebar() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        className="md:hidden fixed top-4 left-4 z-20 p-2 rounded-md bg-white dark:bg-black"
+        onClick={() => setOpen(true)}
+        aria-label="Open menu"
+      >
+        <Menu className="w-6 h-6" />
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/50 z-10 md:hidden"
+          onClick={() => setOpen(false)}
+        />
+      )}
+      <aside
+        className={cn(
+          "fixed z-20 top-0 left-0 h-full w-64 bg-white dark:bg-black p-4 flex flex-col gap-4 transition-transform transform",
+          open ? "translate-x-0" : "-translate-x-full md:translate-x-0"
+        )}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <Link href="/">
+            <Logo />
+          </Link>
+          <button
+            className="md:hidden p-2"
+            onClick={() => setOpen(false)}
+            aria-label="Close menu"
+          >
+            <X className="w-6 h-6" />
+          </button>
+        </div>
+        <nav className="flex flex-col gap-2">
+          <Link href="/events" className="flex items-center gap-2 font-medium hover:underline">
+            <Calendar className="w-4 h-4" /> Eventos
+          </Link>
+        </nav>
+        <div className="mt-auto">
+          <ModeToggle />
+        </div>
+      </aside>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a responsive `Sidebar` component with mobile toggle
- update root layout to use the new sidebar

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_683f84537f6883228fc7e94aa644457c